### PR TITLE
Change libiio to run_export libiio-c, fixing DSO warnings.

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set version = "0.21" %}
-{% set build_num = "5" %}
+{% set build_num = "6" %}
 
 package:
   name: libiio-split
@@ -94,7 +94,7 @@ outputs:
   - name: libiio
     build:
       run_exports:
-        - {{ pin_subpackage('libiio', max_pin='x.x') }}
+        - {{ pin_subpackage('libiio-c', max_pin='x.x') }}
     requirements:
       run:
         - {{ pin_subpackage('libiio-c', exact=True) }}


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
